### PR TITLE
Add README

### DIFF
--- a/.pipeline/README.md
+++ b/.pipeline/README.md
@@ -27,7 +27,7 @@ This README goes into the detail of our `Jenkinsfile`.
 
 The `agent` directive instructs the controller about where the individual step should run. If this directive is used at the beginning of the pipeline, it means that the specified agent will be responsible for executing all of the steps.
 
-The value `default` is used because the agent is configured to run only if there is a matching label expression on the pipeline declaration.
+The value `default` is used because that is the agent's label and the agent is configured to run only if there is a matching label expression on the pipeline declaration.
 
 ## <a id='options' /> `options`
 
@@ -40,6 +40,12 @@ The sole purpose of using a `triggers` directive is to enable version control po
 Polling needs to be enabled in order to trigger builds via local Git commits.
 
 The `notifyCommit` endpoint of Jenkins Git plugin only works if polling is enabled on the pipeline.
+
+---
+
+PS: `pollSCM('')` does not actually poll the repository, it is just there to enable the polling.
+
+---
 
 ## <a id='environment' /> `environment`
 
@@ -64,7 +70,7 @@ This step is added to visualize the environment variables that exist on the agen
 
 ## <a id='checkout' /> Checkout
 
-This step is not actually a real checkout, instead it takes advantage of the bind mount `/home/enkins/agent/repo`.
+This step is not actually a real checkout, instead it takes advantage of the bind mount `/home/jenkins/agent/repo`.
 Since the changes done on a bind mount is synced both ways, this eliminates the need for cloning the actual repository. A simple copy to the target workspace is enough to simulate a checkout.
 
 ---
@@ -96,6 +102,6 @@ There are some simple post actions which does different things depending on the 
 
 ## <a id='utilities' /> Utilities
 
-Besides the steps, there is a utility function which is implemented to remove printing the commands on Console Output.
+Besides the steps, there is a utility function which is implemented to disable printing the commands on Console Output.
 
 This is done by using toggling the shell mode (`set +x` and `set -x`).

--- a/.pipeline/README.md
+++ b/.pipeline/README.md
@@ -1,0 +1,101 @@
+# Jenkinsfile
+
+A `Jenkinsfile` is the pipeline definition that is used by a Jenkins controller.
+Each step in the `Jenkinsfile` is executed by either the controller (by default - though not recommended) or a designated agent based on how the build environment is configured.
+
+This README goes into the detail of our `Jenkinsfile`.
+
+## Table of Contents
+
+<!--toc:start-->
+
+- [`agent`](#agent)
+- [`options`](#options)
+- [`triggers`](#triggers)
+- [`environment`](#environment)
+- [Clean Workspace](#clean-workspace)
+- [Dump Environment Variables](#dump-environment-variables)
+- [Checkout](#checkout)
+- [Start Build Container](#start-build-container)
+- [CI Checks](#ci-checks)
+- [Post Actions](#post-actions)
+- [Utilities](#utilities)
+
+<!--toc:end-->
+
+## <a id='agent' /> `agent`
+
+The `agent` directive instructs the controller about where the individual step should run. If this directive is used at the beginning of the pipeline, it means that the specified agent will be responsible for executing all of the steps.
+
+The value `default` is used because the agent is configured to run only if there is a matching label expression on the pipeline declaration.
+
+## <a id='options' /> `options`
+
+This directive is used to prevent the default checkout mechanism of Declarative Pipeline.
+Since the repository is bind mounted onto the controller and the agent, a Git checkout is not needed.
+
+## <a id='triggers' /> `triggers`
+
+The sole purpose of using a `triggers` directive is to enable version control polling.
+Polling needs to be enabled in order to trigger builds via local Git commits.
+
+The `notifyCommit` endpoint of Jenkins Git plugin only works if polling is enabled on the pipeline.
+
+## <a id='environment' /> `environment`
+
+The `environment` directive is used to define variables that are used frequently throughout the build. Here is a brief explanation of them:
+
+- `TIMEOUT`: This variable is used as a command that is given to the ephemeral build container. The value is set to default Jenkins timeout.
+- `IMAGE`: This is the image that will be used to spin up a build container.
+- `CONTAINER_NAME`: A unique name that represents containers that are associated with each build.
+- `EXEC`: This is used as an alias during each step to make it easier to run commands on the build container.
+
+## <a id='clean-workspace' /> Clean Workspace
+
+The very first step of the pipeline is cleaning up the previous build's results.
+This contains:
+
+- Previous mock "checkout" of the repository,
+- Stopping and removing the ephemeral container.
+
+## <a id='dump-environment-variables' /> Dump Environment Variables
+
+This step is added to visualize the environment variables that exist on the agent on each build.
+
+## <a id='checkout' /> Checkout
+
+This step is not actually a real checkout, instead it takes advantage of the bind mount `/home/enkins/agent/repo`.
+Since the changes done on a bind mount is synced both ways, this eliminates the need for cloning the actual repository. A simple copy to the target workspace is enough to simulate a checkout.
+
+---
+
+PS: It is also possible to spin up another container as a Git server and then serve the repository from there (to both controller and agent), but I used bind mounts instead to keep things simple.
+
+Also, I wanted to keep everything in local so that is the reason why Github or any other remote VCS is not used.
+
+---
+
+## <a id='start-build-container' /> Start Build Container
+
+After the checkout step, the pipeline starts the build container to do the checks.
+If `${IMAGE}` exists from previous builds, it does not pull the image again.
+
+This step starts the build container with a unique name to allow the developers to troubleshoot a certain issue.
+
+## <a id='ci-checks' /> CI Checks
+
+When the build container is started, the pipeline executes the CI checks which are simple `make` targets (`make lint` and `make unit-tests`).
+
+## <a id='post-actions' /> Post Actions
+
+There are some simple post actions which does different things depending on the state of the pipeline:
+
+- `always`: Regardless of the state of the pipeline, the build containers are stopped.
+- `success`: Upon a successful build, the build container is removed entirely.
+- `failure`: Upon a failed build, the build container is left untouched thus it can be inspected later on.
+
+## <a id='utilities' /> Utilities
+
+Besides the steps, there is a utility function which is implemented to remove printing the commands on Console Output.
+
+This is done by using toggling the shell mode (`set +x` and `set -x`).

--- a/.pipeline/local/jenkins-agent/Containerfile
+++ b/.pipeline/local/jenkins-agent/Containerfile
@@ -1,7 +1,7 @@
 FROM quay.io/podman/stable
 
 ARG AGENT_USER="jenkins"
-ARG AGENT_SSH_PUB_KEY_PATH="./.pipeline/local/jenkins-agent/agent-ssh-key.pub"
+ARG PUBLIC_SSH_KEY_PATH="./.pipeline/local/jenkins-agent/agent-ssh-key.pub"
 ARG AGENT_SSHD_PATH=/home/${AGENT_USER}/.ssh
 
 # Install Java and OpenSSH for our Jenkins agent.
@@ -19,7 +19,7 @@ RUN mkdir /home/${AGENT_USER}/agent /home/${AGENT_USER}/.ssh
 
 # Configure SSHD.
 # 1 - Send the public key under /home/jenkins/.ssh/authorized_keys to recognize our controller as a verified SSH client. (private key is registered on controller)
-COPY --chown=${AGENT_USER}:${AGENT_USER} ${AGENT_SSH_PUB_KEY_PATH} ${AGENT_SSHD_PATH}/authorized_keys
+COPY --chown=${AGENT_USER}:${AGENT_USER} ${PUBLIC_SSH_KEY_PATH} ${AGENT_SSHD_PATH}/authorized_keys
 # 2 - Create SSHD host keys.
 RUN ssh-keygen -t rsa -N '' -C '' -f ${AGENT_SSHD_PATH}/id_rsa -q; ssh-keygen -t dsa -N '' -C '' -f ${AGENT_SSHD_PATH}/id_dsa -q; ssh-keygen -t ed25519 -N '' -C '' -f ${AGENT_SSHD_PATH}/id_ed25519 -q
 # 3 - Create sshd_config under SSHD_CONFIG_PATH.

--- a/.pipeline/local/jenkins-agent/README.md
+++ b/.pipeline/local/jenkins-agent/README.md
@@ -1,0 +1,54 @@
+# Jenkins Agent Setup
+
+The main bulk of the work happens on the agent, so it is important to understand how it is configured.
+
+The Jenkins agent in this project is configured to satisfy the requirements below:
+
+- It should have Java installed,
+- It should have SSH to allow remote connections from controller,
+- It should use Podman to run ephemeral containers during the pipeline execution.
+
+The `Containerfile` in this directory serves to fulfill these requirements.
+
+## Table of Contents
+
+<!--toc:start-->
+
+- [Base Image](#base-image)
+- [Agent Executable](#agent-executable)
+- [SSH](#ssh)
+
+<!--toc:end-->
+
+## <a id='base-image' /> Base Image
+
+For the agent, Podman is used as a base image because the agent needs a container engine to boot up ephemeral containers during the pipeline execution.
+
+Since the agent itself is running in a Podman container, having Podman as a base image turns the agent into what is called Podman-in-Podman (PinP). This is really similar to the term Docker-in-Docker (DinD).
+
+The reason why I'm using Podman is:
+
+- I'm currently using Podman in my main host, and I did not want to mix both technologies because it is advised to go all Podman or Docker.
+- In DinD approach, the container starts up multiple processes and additional configuration is needed for the container users to use Docker without elevated privileges. For Podman, all you need to do is to include the base image and that is it. If you check the container, you will see that `podman` does not run a daemon unlike `docker`, which is an additional plus.
+- Everything is rootless and least privilege principle is enforced by default, which is quite nice to have even for a PoC.
+
+## <a id='agent-executable' /> Agent Executable
+
+A Jenkins agent is essentially a small `java` executable which is transferred from a Jenkins controller at the beginning of any job.
+So, Java 17 is added to the image (the same version used for the controller).
+
+## <a id='ssh' /> SSH
+
+As a last point, `openssh-server` is added to our agent image to spin up a SSH server.
+
+To make things a little bit more interesting, instead of running SSH server as `root`, it is configured to be run as the user `jenkins`, which is the same user that the controller uses to connect.
+
+To achieve this, here is a list of the changes that is done after `openssh-server` installation:
+
+- `.ssh` directory is created for the user `jenkins`,
+- The public key of the controller (which is created during the installation) is copied as `authorized_keys` to allow our controller to connect,
+- Necessary SSHD host keys are added under `.ssh`,
+- A basic SSHD config is added as `sshd_config`, similar to `/etc/ssh/sshd_config`.
+- The port 2222 is exposed (since the container is rootless, the well-known default port 22 is not used).
+
+Finally, an entrypoint is defined at the end to run SSHD with the user `jenkins`.

--- a/.pipeline/local/jenkins-controller/Containerfile
+++ b/.pipeline/local/jenkins-controller/Containerfile
@@ -8,7 +8,7 @@ ENV AGENT_PRIVATE_SSH_KEY_PATH="/var/jenkins_home/config/agent-ssh-key"
 ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
 
 # Define the default build argument for our private SSH key. 
-ARG HOST_PRIVATE_SSH_KEY_PATH="./.pipeline/local/jenkins-controller/agent-ssh-key"
+ARG PRIVATE_SSH_KEY_PATH="./.pipeline/local/jenkins-controller/agent-ssh-key"
 
 # Create the base config folder that Jenkins will use.
 RUN mkdir /var/jenkins_home/config
@@ -20,4 +20,4 @@ RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
 # Copy our controller config into the container.
 COPY --chown=jenkins:jenkins ["./.pipeline/local/jenkins-controller/config.yml", "./.pipeline/local/jenkins-controller/local-multibranch.groovy", "/var/jenkins_home/config/"]
 # Copy the private key into the container.
-COPY --chown=jenkins:jenkins ${HOST_PRIVATE_SSH_KEY_PATH} ${AGENT_PRIVATE_SSH_KEY_PATH}
+COPY --chown=jenkins:jenkins ${PRIVATE_SSH_KEY_PATH} ${AGENT_PRIVATE_SSH_KEY_PATH}

--- a/.pipeline/local/jenkins-controller/README.md
+++ b/.pipeline/local/jenkins-controller/README.md
@@ -55,7 +55,7 @@ Here is a list and a brief explanation of the plugins in `plugins.txt`:
 ## <a id='yaml-configuration' /> YAML Configuration
 
 `config.yml` is the main file that is used to configure Jenkins.
-There are comments added for most of the individual option, but generally it consists of 4 main parts:
+There are comments added for most of the individual option, but generally it consists of 6 main parts:
 
 - System configuration
 - System tool configuration

--- a/.pipeline/local/jenkins-controller/README.md
+++ b/.pipeline/local/jenkins-controller/README.md
@@ -1,6 +1,6 @@
 # Jenkins Controller Setup
 
-This directory contains all files (except the private SSH key) necessary to run a our desired Jenkins controller.
+This directory contains all necessary files (except the private SSH key) to run our desired Jenkins controller.
 
 ## Table of Contents
 
@@ -10,6 +10,7 @@ This directory contains all files (except the private SSH key) necessary to run 
 - [Controller Plugins](#controller-plugins)
 - [YAML Configuration](#yaml-configuration)
 - [Multibranch Pipeline](#multibranch-pipeline)
+- [SSH Configuration](#ssh-configuration)
 <!--toc:end-->
 
 ## <a id='containerfile' /> Containerfile
@@ -91,3 +92,13 @@ All this script does is to define a Multibranch Pipeline with the options below:
 - Finally, it defines a strategy to keep only one build item of a removed branch, and discard the rest.
 
 In order to understand what can be used in this script, you can go to `/plugin/job-dsl/api-viewer/index.html` to see the whole `job-dsl` documentation.
+
+## <a id='ssh-configuration' /> SSH Configuration
+
+The SSH private key is not here by default because it is expected from users to generate the private key.
+
+When it is generated, the key is used by `config.yml` to store it as a system wide credential in Jenkins.
+
+The credential is used by the controller to launch the agent whenever a build is triggered either manually or via a Git commit.
+
+The public key is used on agent to establish a successful SSH connection so check the agent's README to understand the other half of the equation.

--- a/.pipeline/local/jenkins-controller/README.md
+++ b/.pipeline/local/jenkins-controller/README.md
@@ -1,0 +1,93 @@
+# Jenkins Controller Setup
+
+This directory contains all files (except the private SSH key) necessary to run a our desired Jenkins controller.
+
+## Table of Contents
+
+<!--toc:start-->
+
+- [Containerfile](#containerfile)
+- [Controller Plugins](#controller-plugins)
+- [YAML Configuration](#yaml-configuration)
+- [Multibranch Pipeline](#multibranch-pipeline)
+<!--toc:end-->
+
+## <a id='containerfile' /> Containerfile
+
+This file is used to create a custom Jenkins controller image.
+The only reason to use a custom Containerfile is to use _configuration-as-code_ Jenkins plugin to setup the controller via YAML.
+
+The whole idea of YAML configuration is to turn the controller environment into something that can be easily reproducable.
+
+Instead of configuration-as-code, you can also use:
+
+- A named volume to persist `/var/jenkins_home`,
+- Take export the volume after you configure the controller via UI,
+- Create a `Containerfile` and import the contents of the volume on top of the base image.
+
+The layers of `Containerfile` is ordered in a way that utilizes the layer caching as much as possible:
+
+- Throughout the development, I found that most of the time I tinkered with the configuration file `config.yml` and SSH keys. Therefore I put them at the bottom.
+- The plugin installation `jenkins-plugin-cli` takes a lot of time and does not need to be updated that frequently compared to `config.yml`. Therefore it is located above the config and SSH keys.
+
+All the files in this directory are there because of this `Containerfile`, so let's look at them.
+
+## <a id='controller-plugins' /> Controller Plugins
+
+The Jenkins ecosystem utilizes plugins to extend the base functionality of the tool itself.
+This project requires a couple of plugins, and since the main goal is to make the configuration reproducable, there is a need to define the plugins and install them via `Containerfile`.
+
+That is why, there is a file called `plugins.txt` which is used by `jenkins-plugin-cli` to install the required plugins.
+
+Here is a list and a brief explanation of the plugins in `plugins.txt`:
+
+- `configuration-as-code`: Allows us to configure Jenkins via YAML.
+- `git`: Enables polling and build triggers via Git.
+- `workflow-multibranch`: Scans the branches of a repository and automatically creates Pipeline projects from them, preventing us from manually creating each Pipeline.
+- `pipeline-model-definition`: Allows us to write Declarative Pipeline's instead of Scriptive.
+- `ssh-slaves`: Allows the Jenkins controller to connect to an agent via SSH, instead of inbound TCP.
+- `ssh-agent`: Allows a Jenkins agent to use SSH credentials. It is optional.
+- `pipeline-stage-view`: It visualizes the steps of a pipeline in the main page.
+- `dark-theme`: Enables dark theme in Jenkins. Optional as well.
+- `job-dsl`: Enables us to define `jobs` in the configuration YAML.
+
+## <a id='yaml-configuration' /> YAML Configuration
+
+`config.yml` is the main file that is used to configure Jenkins.
+There are comments added for most of the individual option, but generally it consists of 4 main parts:
+
+- System configuration
+- System tool configuration
+- Pipeline configuration
+- Credentials
+- Plugin configuration
+- Theme
+
+Unfortunately, the documentation around `configuration-as-code` is not that detailed, and it requires you to do a lot of trial and errors.
+
+There are example configurations in [its main repository](https://github.com/jenkinsci/configuration-as-code-plugin), but if you cannot find an example for your needs, there are a couple of things you can do:
+
+- You can configure Jenkins via UI, and then view the configuration under `/manage/configuration-as-code/viewExport` and put this export in version control.
+- You can try to find your way through the JSON schema, which is located on `/manage/configuration-as-code/schema`.
+
+Please keep in mind that you can't configure Jenkins by using both `configuration-as-code` and the UI itself.
+
+If you use `configuration-as-code`, anything you do via UI gets overwritten when the instance is restarted.
+
+## <a id='multibranch-pipeline' /> Multibranch Pipeline
+
+The last file we can mention is `local-multibranch.groovy`, which is a Groovy script that is used by `config.yml` to define our Multibranch Pipeline via code.
+
+Unfortunately, in order to define jobs via `configuration-as-code`, we need to utilize `job-dsl` plugin and use a Groovy script.
+Jobs are not configurable with YAML.
+
+All this script does is to define a Multibranch Pipeline with the options below:
+
+- By default, Jenkins checks the root of the repository to find the `Jenkinsfile`. In this project, the `Jenkinsfile` is actually under `.pipeline` so the default location is changed.
+
+- Instead of taking Github as the main branch source, it takes the local Git repository. The remote location format `file://<repo-location>` is the format that is used by `git clone`.
+  You can check `man git-clone` to see the available Git URLs.
+
+- Finally, it defines a strategy to keep only one build item of a removed branch, and discard the rest.
+
+In order to understand what can be used in this script, you can go to `/plugin/job-dsl/api-viewer/index.html` to see the whole `job-dsl` documentation.

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,46 @@ unit-tests:
 .PHONY: lint
 lint:
 	cd src; golangci-lint run -v; cd -;
+
+.PHONY: ssh-pair
+ssh-pair:
+	ssh-keygen -t ed25519 -C '' -N '' -f ./agent-ssh-key; \
+		mv ./agent-ssh-key ./.pipeline/local/jenkins-controller; \
+		mv ./agent-ssh-key.pub ./.pipeline/local/jenkins-agent
+
+.PHONY: images
+images:
+	podman build -t jenkins-controller:0.0 -f ./.pipeline/local/jenkins-controller/Containerfile . && \
+		podman build -t jenkins-agent:0.0 -f ./.pipeline/local/jenkins-agent/Containerfile .
+
+.PHONY: net
+net:
+	podman network create ci --subnet 10.89.0.0/29
+
+.PHONY: install
+install:
+	make ssh-pair && make images && make net
+
+.PHONY: build-trigger
+build-trigger:
+	cp ./.pipeline/local/jenkins-agent/post-commit ./.git/hooks/post-commit
+
+.PHONY: start
+start:
+	podman run --name jenkins-controller \
+		-d -p 8080:8080 \
+		--network ci --ip 10.89.0.2 \
+		-v ./:/var/jenkins_home/repo \
+		localhost/jenkins-controller:0.0 && \
+	podman run --name jenkins-agent \
+		-d -p 2222:2222 \
+		--network ci --ip 10.89.0.3 \
+		-v ./:/home/jenkins/agent/repo \
+		--privileged \
+		localhost/jenkins-agent:0.0
+
+.PHONY: rm
+rm:
+	podman network rm --force ci && \
+		podman image rm localhost/jenkins-controller:0.0 localhost/jenkins-agent:0.0
+		rm ./.pipeline/local/jenkins-controller/agent-ssh-key ./.pipeline/local/jenkins-agent/agent-ssh-key.pub

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,5 @@ start:
 .PHONY: rm
 rm:
 	podman network rm --force ci && \
-		podman image rm localhost/jenkins-controller:0.0 localhost/jenkins-agent:0.0
+		podman image rm localhost/jenkins-controller:0.0 localhost/jenkins-agent:0.0 && \
 		rm ./.pipeline/local/jenkins-controller/agent-ssh-key ./.pipeline/local/jenkins-agent/agent-ssh-key.pub

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 
 .PHONY: build-trigger
 build-trigger:
-	cp ./.pipeline/local/jenkins-agent/post-commit ./.git/hooks/post-commit
+	chmod ug+x ./.pipeline/local/jenkins-agent/post-commit; cp ./.pipeline/local/jenkins-agent/post-commit ./.git/hooks/post-commit;
 
 .PHONY: start
 start:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Here is a list of README's you can check to learn more about each specific part 
 - [Service](./src/README.md)
 - [Controller](./.pipeline/local/jenkins-controller/README.md)
 - [Agent](./.pipeline/local/jenkins-agent/README.md)
-- [Jenkinsfile](#to-be-filled)
+- [Jenkinsfile](./.pipeline/README.md)
 
 ## <a id='issues'/> Issues
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,12 @@ Let's see how to get this project up and running.
 
 ### <a id='starting-the-build-environment'/> Starting the Build Environment
 
-To start the build environment, you can run `make start`.
+To start the build environment, run:
+
+```bash
+make start
+```
+
 Shortly after, you will see 2 containers running successfully (`jenkins-controller` and `jenkins-agent`).
 
 Jenkins UI is served through `127.0.0.1:8080`, so you can login to Jenkins with user and password `admin` and check around.
@@ -217,7 +222,12 @@ So, follow the steps below to setup the trigger.
 In that page, there is a section called "Git plugin notifyCommit access tokens".
 Create a token from there and put it in `post-commit` script.
 
-2 - Run the make target `make build-trigger`.
+2 - Run the make target below:
+
+```bash
+make build-trigger
+```
+
 This is a simple `cp` script that puts the `post-commit` script under `.git/hooks` to be used by Git itself. Nothing special.
 
 And that's it!

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ This will wipe out pretty much everything you've done during the installation ex
 Here is a list of README's you can check to learn more about each specific part of this PoC:
 
 - [Service](./src/README.md)
-- [Controller](#to-be-filled)
-- [Agent](#to-be-filled)
+- [Controller](./.pipeline/local/jenkins-controller/README.md)
+- [Agent](./.pipeline/local/jenkins-agent/README.md)
 - [Jenkinsfile](#to-be-filled)
 
 ## <a id='issues'/> Issues

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ However, there are some issues with local testing, which comes up frequently as 
 - Non-reproducable remote configurations, which prevents local testing as a whole and causes developers to try alternative, non-reliable solutions.
 
 So, the goal of this project is to locally test the pipelines we use instead of doing trial and error on a remote pipeline.
-With this approach, we can _test_ the actual pipeline steps before deploying our application and fix any problems before hitting the actual servers.
+With this approach, we can _test_ the actual pipeline steps before deploying our service and fix any problems before hitting the actual servers.
 
 It also provides me a nice playground to work with containers and pipelines, so why not!
 
@@ -44,7 +44,7 @@ It also provides me a nice playground to work with containers and pipelines, so 
 
 When it comes to what to use for this PoC, my choices were quite straightforward:
 
-The application itself is really simple and the type of application (API, lambda, scheduler, etc.) doesn't matter that much. It just needs to have one test and a feature to be tested.
+The service itself is really simple and the type of service (API, lambda, scheduler, etc.) doesn't matter that much. It just needs to have one test and a feature to be tested.
 So for the language, I choose **Golang**:
 
 - It's really fun to play, I don't know why.
@@ -88,7 +88,7 @@ alias docker=podman
 
 Keep in mind that I did not developed with Docker, so I do not guarantee that the above method works seamlessly.
 
-Other than this, if you want to play with the application itself, you need to have [Golang runtime](https://go.dev/dl/) installed on your host as well.
+Other than this, if you want to play with the service itself, you need to have [Golang runtime](https://go.dev/dl/) installed on your host as well.
 
 ## <a id='installation'/> Installation
 
@@ -189,14 +189,14 @@ The configuration is written in a way that triggers an initial build for each pi
 
 Seeing a green icon next to the pipeline means that the controller has successfully connected to the agent via SSH and the `Jenkinsfile` has been executed successfully.
 
-From here on, you can check each multibranch pipeline to see their console output or you can go back to the application and make some changes to trigger the build.
+From here on, you can check each multibranch pipeline to see their console output or you can go back to the service and make some changes to trigger the build.
 
 ### <a id='triggering-a-build'/> Triggering a Build
 
 The next step would be to trigger a build to test our pipeline.
 There are 2 ways of doing it, and you can go with the one that you prefer the most:
 
-- You can trigger a build manually after doing a change in the application.
+- You can trigger a build manually after doing a change in the service.
 - You can notify Jenkins after an event (e.g Git push) and Jenkins can start the build with the latest change.
 
 To trigger a build manually, you can go to the pipeline page from Jenkins UI: `/job/ci-pipeline/`.
@@ -237,7 +237,7 @@ This will wipe out pretty much everything you've done during the installation ex
 
 Here is a list of README's you can check to learn more about each specific part of this PoC:
 
-- [Application](#to-be-filled)
+- [Service](./src/README.md)
 - [Controller](#to-be-filled)
 - [Agent](#to-be-filled)
 - [Jenkinsfile](#to-be-filled)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,261 @@
-# Local CI/CD with Jenkins
+# Local CI with Jenkins
 
-This placeholder README will be updated once the PoC is finished.
+This PoC contains a simple configuration to see what it takes to run Jenkins locally to test a pipeline or the CI checks of a project.
+
+## Table of Contents
+
+<!--toc:start-->
+
+- [First, The "Why"](#first-the-why)
+- [Decisions, Decisions](#decisions-decisions)
+- [The "Goal"](#the-goal)
+- [Requirements](#requirements)
+- [Installation](#installation)
+  - [One Command to Install Them All](#one-command-to-install-them-all)
+  - [Create an SSH Key/Pair](#create-an-ssh-keypair)
+  - [Create Podman Images](#create-podman-images)
+  - [Create CI Network](#create-ci-network)
+- [Usage](#usage)
+  - [Starting the Build Environment](#starting-the-build-environment)
+  - [Triggering a Build](#triggering-a-build)
+    - [Triggering a Build With Git Commit](#triggering-a-build-with-git-commit)
+  - [Cleaning Up](#cleaning-up)
+- [More Details](#more-details)
+- [Issues](#issues)
+- [TODO](#todo)
+<!--toc:end-->
+
+## <a id='first-the-why'/> First, The "Why"
+
+Local testing, in any context, is done to receive a faster feedback about the thing we try to develop.
+It is also done to ensure that the things we develop actually behave like we want on remote servers.
+
+However, there are some issues with local testing, which comes up frequently as the phrase "But it works on my machine!":
+
+- Version mismatch between local and remote, causing unknown issues (mostly) during deployment and loss in velocity.
+- Non-reproducable remote configurations, which prevents local testing as a whole and causes developers to try alternative, non-reliable solutions.
+
+So, the goal of this project is to locally test the pipelines we use instead of doing trial and error on a remote pipeline.
+With this approach, we can _test_ the actual pipeline steps before deploying our application and fix any problems before hitting the actual servers.
+
+It also provides me a nice playground to work with containers and pipelines, so why not!
+
+## <a id='decisions-decisions'/> Decisions, Decisions
+
+When it comes to what to use for this PoC, my choices were quite straightforward:
+
+The application itself is really simple and the type of application (API, lambda, scheduler, etc.) doesn't matter that much. It just needs to have one test and a feature to be tested.
+So for the language, I choose **Golang**:
+
+- It's really fun to play, I don't know why.
+- It's pretty dead simple to get it up and running, you just have an entrypoint and a module state and that's it, which is perfect for this project.
+- It's tooling is amazing to work with.
+
+Regarding the CI tool, my weapon of choice is **Jenkins**:
+
+- It is by far the most commonly used tool in the industry, we can't deny it.
+- I already actively use Github Actions in where I work, so I wanted to try something else to add a little bit more challenge.
+
+## <a id='the-goal'/> The "Goal"
+
+The goal of this project is to create an environment where you can locally check the CI steps of a pipeline.
+Normally, a pipeline can be quite complex based on the actual need, so in order to make this PoC manageable I went with a couple of requirements:
+
+- It should be possible to containerize the entire build environment, to make it reproducable among developers.
+- It is forbidden to install any language runtime on the Jenkins agent other than Java. The agent should stay as clean as possible.
+- The pipeline should spin up ephemeral containers to execute the CI steps, and then remove them when there is no error.
+- If there is an error, it should be visible to the output and developers should be able to exec into the build container to troubleshoot the issue.
+- Any Docker image can be used by the actual pipeline.
+
+## <a id='requirements'/> Requirements
+
+In order to run this PoC locally, you need to install [Podman](https://podman.io/) on your host.
+
+I used Podman because the idea of rootless containers and a native systemd integration sounds a LOT better than what Docker offers at the moment:
+
+- A gigantic daemon,
+- Single point of failure,
+- Rootful (by default)
+
+Podman really feels like it is **the** perfect transition to Kubernetes.
+Also, it was something I did not work with before, so I wanted to try it out.
+
+PS: Podman claims that it is a drop-in replacement of Docker, so you can try to run the project by using a simple alias on your shell environment:
+
+```bash
+alias docker=podman
+```
+
+Keep in mind that I did not developed with Docker, so I do not guarantee that the above method works seamlessly.
+
+Other than this, if you want to play with the application itself, you need to have [Golang runtime](https://go.dev/dl/) installed on your host as well.
+
+## <a id='installation'/> Installation
+
+The installation is done through `make` targets for you to run as easily as possible.
+Do not try to run the targets without looking at here first, because the ordering matters if you wish to change one of the steps for your own preferences.
+
+All of the installation steps should be run at the project root.
+
+### <a id='one-command-to-install-them-all'/> One Command to Install Them All
+
+If you just want to run this project as fast as possible, just run the target below:
+
+```bash
+make install
+```
+
+This sets up pretty much everything with defaults, so if you use this you can skip to the next section.
+If you wish to learn more about what is going on, I would recommend you to keep reading.
+
+### <a id='create-an-ssh-keypair'/> Create an SSH Key/Pair
+
+The very first step of the installation is to create an _ed25519_ SSH key/pair.
+
+The build environment consists of a single Jenkins controller and a permanent Jenkins node (agent).
+Each time a build is triggered, the controller is connected to the agent via SSH.
+So we need to have this key pair first before moving on.
+
+```bash
+make ssh-pair
+```
+
+This `make` target places two keys in specific directories:
+
+- `agent-ssh-key.pub`: The public SSH key for our SSH communication, this goes to our agent -> `.pipeline/local/jenkins-agent`.
+- `agent-ssh-key`: The private SSH key, this goes to our controller -> `.pipeline/local/jenkins-controller`.
+
+I would recommend you to not change the key names or their locations, otherwise you would need to make changes in other steps as well.
+
+### <a id='create-podman-images'/> Create Podman Images
+
+The next step is creating our Jenkins controller and agent images which we use to create our build environment.
+
+```bash
+make images
+```
+
+This `make` target does the following:
+
+- It reads the `Containerfile`s under `.pipeline/local/jenkins-agent` and `.pipeline/local/jenkins-controller` and creates Podman images from them.
+- It copies necessary configuration files and SSH keys to the images based on the defaults.
+- It tags the images as `jenkins-controller` and `jenkins-agent`, so later on you can work with these images manually if you want.
+
+If you decide to change the location or names of your SSH keys, you need to update the script to override the build arguments:
+
+```bash
+podman build -t jenkins-controller ./.pipeline/local/jenkins-controller/Containerfile --build-arg PRIVATE_SSH_KEY_PATH=<private-key-location> .
+podman build -t jenkins-agent ./.pipeline/local/jenkins-agent/Containerfile --build-arg PUBLIC_SSH_KEY_PATH=<pub-key-location> .
+```
+
+### <a id='create-ci-network'/> Create CI Network
+
+Our controller and agent need to be in the same network in order to communicate.
+To make things simple, run the target below to create a persistent named network `ci` with a specific subnet `10.89.0.0/29`.
+
+```bash
+make net
+```
+
+In the project, the controller is set up to run on `10.89.0.2` and the agent is on `10.89.0.3`.
+The IP of agent is important since this value is used during SSH, therefore if you decide to change it you can manually create a network and add custom IP's to Jenkins configuration as well.
+
+---
+
+And that's it.
+Like I said before, you can just use `make install` to do a one step installation, and later on check the scripts to see what they actually do.
+
+## <a id='usage'/> Usage
+
+The usage is pretty straightforward, like you would expect from a pipeline:
+
+- A change is made on the project,
+- That change triggers a builds on the pipeline,
+- The pipeline gives a feedback about the change.
+
+Let's see how to get this project up and running.
+
+### <a id='starting-the-build-environment'/> Starting the Build Environment
+
+To start the build environment, you can run `make start`.
+Shortly after, you will see 2 containers running successfully (`jenkins-controller` and `jenkins-agent`).
+
+Jenkins UI is served through `127.0.0.1:8080`, so you can login to Jenkins with user and password `admin` and check around.
+
+### <a id='multibranch-pipeline'/> Multibranch Pipeline
+
+When you first login your Jenkins instance and go to `/job/ci-pipeline`, you will see that Jenkins scans the repository to configure a Multibranch pipeline.
+The configuration is written in a way that triggers an initial build for each pipeline in a multibranch project.
+
+Seeing a green icon next to the pipeline means that the controller has successfully connected to the agent via SSH and the `Jenkinsfile` has been executed successfully.
+
+From here on, you can check each multibranch pipeline to see their console output or you can go back to the application and make some changes to trigger the build.
+
+### <a id='triggering-a-build'/> Triggering a Build
+
+The next step would be to trigger a build to test our pipeline.
+There are 2 ways of doing it, and you can go with the one that you prefer the most:
+
+- You can trigger a build manually after doing a change in the application.
+- You can notify Jenkins after an event (e.g Git push) and Jenkins can start the build with the latest change.
+
+To trigger a build manually, you can go to the pipeline page from Jenkins UI: `/job/ci-pipeline/`.
+From there, click on the branch you want to run the build, and then press "Build Now".
+
+You can also trigger a build automatically via _Git commits_, to run the project as frictionless as possible.
+
+#### <a id='triggering-a-build-with-git-commit'/> Triggering a Build With Git Commit
+
+In order to setup a Git commit trigger, we need to have 2 things:
+
+- A `post-commit` Git hook, which is used by Git upon any successful commit.
+- An access token to authenticate our local repository to securely notify Jenkins.
+
+So, follow the steps below to setup the trigger.
+
+1 - Login to Jenkins and navigate to `/manage/configureSecurity`.
+In that page, there is a section called "Git plugin notifyCommit access tokens".
+Create a token from there and replace "<insert-your-token-here>" in `post-commit` script with it.
+
+2 - Run the make target `make build-trigger`.
+This is a simple `cp` script that puts the `post-commit` script under `.git/hooks` to be used by Git itself. Nothing special.
+
+And that's it!
+Now whenever you commit a change, you can immediately see a build on the queue under `/job/ci-pipeline/<your-branch-name>`.
+
+### <a id='cleaning-up'/> Cleaning Up
+
+If you want to destroy the entire build environment, you can simply run our last `make` target:
+
+```bash
+make rm
+```
+
+This will wipe out pretty much everything you've done during the installation except the images.
+
+## <a id='more-details'/> More Details
+
+Here is a list of README's you can check to learn more about each specific part of this PoC:
+
+- [Application](#to-be-filled)
+- [Controller](#to-be-filled)
+- [Agent](#to-be-filled)
+- [Jenkinsfile](#to-be-filled)
+
+## <a id='issues'/> Issues
+
+If you encounter any issues, I would love to hear them out!
+At the end, this PoC is done to provide a playground for people who have something similar in their minds.
+
+So if you can't get use this project or it needs too much manual work to be useful, please open a new issue and let me know.
+
+## <a id='todo'/> TODO
+
+Even though this is a PoC project, it doesn't mean it has to stay simple!
+So here is a small list of TODOs that I wish to develop:
+
+- Currently, the `Jenkinsfile` only supports pre-build images.
+  However, there might be some cases where a custom `Dockerfile` or `Containerfile` needs to be used as the build container.
+- More examples with other common steps (artifact generation, notification, etc.) could be better.
+
+So, to address these concerns, it might be a good idea to have a couple of examples to see what we can do with pipelines on our local hosts.

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ From here on, you can check each multibranch pipeline to see their console outpu
 ### <a id='triggering-a-build'/> Triggering a Build
 
 The next step would be to trigger a build to test our pipeline.
-There are 2 ways of doing it, and you can go with the one that you prefer the most:
+There are 2 ways of doing it in this project, and you can go with the one that you prefer the most:
 
 - You can trigger a build manually after doing a change in the service.
-- You can notify Jenkins after an event (e.g Git push) and Jenkins can start the build with the latest change.
+- You can notify Jenkins after a Git event (e.g commit) and Jenkins can start the build with the latest change.
 
 To trigger a build manually, you can go to the pipeline page from Jenkins UI: `/job/ci-pipeline/`.
 From there, click on the branch you want to run the build, and then press "Build Now".
@@ -215,7 +215,7 @@ So, follow the steps below to setup the trigger.
 
 1 - Login to Jenkins and navigate to `/manage/configureSecurity`.
 In that page, there is a section called "Git plugin notifyCommit access tokens".
-Create a token from there and replace "<insert-your-token-here>" in `post-commit` script with it.
+Create a token from there and put it in `post-commit` script.
 
 2 - Run the make target `make build-trigger`.
 This is a simple `cp` script that puts the `post-commit` script under `.git/hooks` to be used by Git itself. Nothing special.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,25 @@
+# The Example Service
+
+To give the whole context, the example service is written in a way that satisfies the requirements below:
+
+- The service should be testable,
+- The service should be checked for linting.
+
+Therefore it is kept as simple as possible to keep the focus on Jenkins.
+
+## Usage
+
+To run the unit tests, you can use:
+
+```bash
+make unit-tests
+```
+
+To run the linter, you can use:
+
+```bash
+make lint
+```
+
+Keep in mind that for the lint, you need to have `golangci-lint` installed on your host if you want to run it locally.
+If you do not want to install, you can rely on Jenkins to run lints for you as that is the whole point of the project.


### PR DESCRIPTION
The main README is updated to contain the necessary documentation, such as:

- Installation,
- Usage,
- The purpose of the project,
- TODO

On top of that, detailed README's are added for the service, the Jenkins controller, and the Jenkins agent to explain how everything is connected together.

Also, it is seen that the exec permission setup was missing for `post-commit` script. So that is added to `make build-trigger` as well.